### PR TITLE
Improve output

### DIFF
--- a/lib/rethfl.ml
+++ b/lib/rethfl.ml
@@ -49,15 +49,15 @@ let report_times () =
 
 let main file =
   let psi, _ = Syntax.parse_file file in
-  Log.app begin fun m -> m ~header:"Input" "%a"
+  Log.info begin fun m -> m ~header:"Input" "%a"
     Print.(hflz_hes simple_ty_) psi
   end;
   let psi = Syntax.Trans.Simplify.hflz_hes psi in
-  Log.app begin fun m -> m ~header:"Simplified" "%a"
+  Log.info begin fun m -> m ~header:"Simplified" "%a"
     Print.(hflz_hes simple_ty_) psi
   end;
   let psi = Syntax.Trans.Peephole.hflz_hes psi in
-  Log.app begin fun m -> m ~header:"Peephole" "%a"
+  Log.info begin fun m -> m ~header:"Peephole" "%a"
     Print.(hflz_hes simple_ty_) psi
   end;
   let psi, top = Syntax.Trans.Preprocess.main psi in
@@ -69,7 +69,7 @@ let main file =
       begin
       (* remove disjunction *)
         let psi = Syntax.Trans.RemoveDisjunction.f psi top in
-        Log.app begin fun m -> m ~header:"RemoveDisj" "%a"
+        Log.info begin fun m -> m ~header:"RemoveDisj" "%a"
           Print.(hflz_hes simple_ty_) psi
         end;
         psi

--- a/lib/typing/chc.ml
+++ b/lib/typing/chc.ml
@@ -3,14 +3,20 @@ open Rtype
 
 type ('head, 'body) chc = {head: 'head; body: 'body}
 
-let print_chc chc = 
-  print_refinement chc.body;
-  Printf.printf " => ";
-  print_refinement chc.head
+let pp_chc ppf chc =
+  (* Maybe head <= body is better ?*)
+  Fmt.pf ppf "@[<2>%a =>@ %a@]" pp_refinement chc.body pp_refinement chc.head
 
-let rec print_constraints = function
-  | [] -> ()
-  | x::xs -> print_chc x; print_newline(); print_constraints xs
+let print_chc chc = 
+  pp_chc Fmt.stdout chc;
+  Fmt.flush Fmt.stdout ()
+
+let pp_constraits ppf chcs =
+    Fmt.pf ppf "@[<v>%a@,@]" (Fmt.list pp_chc) chcs
+
+let print_constraints chcs =
+  pp_constraits Fmt.stdout chcs;
+  Fmt.flush Fmt.stdout ()
 
 (* find x=e in the toplevel of CHC's body, and then replace it by True *)
 let rec find_and_cut_substs rt ids = match rt with 

--- a/lib/typing/chc_solver.ml
+++ b/lib/typing/chc_solver.ml
@@ -7,6 +7,10 @@ module Unix = Core_unix
 
 type solver = [`Spacer | `Hoice | `Fptprove | `Eldarica | `Liu]
 
+let log_src = Logs.Src.create ~doc:"Log for the CHC solver module" "CHC Solver"
+module Log = (val Logs.src_log log_src)
+
+
 let fptprove_path_env = "fptprove"
 
 type unsat_proof_node =
@@ -267,7 +271,7 @@ let parse_model model =
       | (name, args, x)::xs -> (name, args, simplify_def x) :: inner xs
     in inner defs
   in
-  print_string model;
+  Log.info (fun m -> m ~header: "Model" "%s" model);
   match Sexplib.Sexp.parse model with
   | Done(model, _) -> begin
     match model with

--- a/lib/typing/rtype.ml
+++ b/lib/typing/rtype.ml
@@ -3,6 +3,8 @@ open Rid
 open Rresult
 
 
+let log_src = Logs.Src.create ~doc:"Debug log for refinemnet types" "RType"
+module Log = (val Logs.src_log log_src)
 
 let id_source = ref 0
 let id_top = 0
@@ -48,10 +50,12 @@ let generate_rtemplate args = RTemplate(generate_id(), args)
 (* clone *)
 let rec clone_type_with_new_pred ints = function
   | RBool(RTemplate(_, _)) -> RBool(RTemplate(generate_id (), ints))
-  | RBool(_) -> begin
-      print_endline "[Info]: Replacing non-template refinement";
+  | RBool(_) ->
+    Log.info
+    begin fun m ->
+      m "[Info]: Replacing non-template refinement"
+    end;
       RBool(RTemplate(generate_id (), ints))
-    end
   | RArrow(RInt(RId(id)), y) ->
     RArrow(RInt(RId(id)), clone_type_with_new_pred (Arith.Var(id)::ints) y)
   | RArrow(x, y) ->


### PR DESCRIPTION
This PR improves the output/logging feature of ReTHFL.
Currently, ReTHFL outputs lots of debug information to stdout.
For example,
```
$ rethfl input/ok/valid/sum.in 
[Main:App:Input]
  S : int -> bool =ν λn3:int.Sum n3 (λr4:int.n3 <= r4)
  Sum : int -> (int -> bool) -> bool =ν
    λx5:int.λk6:(int -> bool).x5 <= 0 && k6 0 || x5 > 0 && Sum (x5 - 1) (λy7:int.k6 (x5 + y7))
[Main:App:Simplified]
  S : int -> bool =ν λn3:int.Sum n3 (λr4:int.n3 <= r4)
  Sum : int -> (int -> bool) -> bool =ν
    λx5:int.λk6:(int -> bool).x5 <= 0 && k6 0 || x5 > 0 && Sum (x5 - 1) (λy7:int.k6 (x5 + y7))
[Main:App:Peephole]
  S : int -> bool =ν λn3:int.Sum n3 (λr4:int.n3 <= r4)
  Sum : int -> (int -> bool) -> bool =ν
    λx5:int.λk6:(int -> bool).x5 <= 0 && k6 0 || x5 > 0 && Sum (x5 - 1) (λy7:int.k6 (x5 + y7))
S *[X18()]
Sum (x11: int -> ((t12: int -> *[X1(t12,x11)]) -> *[X2(x11)]))


infering new formula: S = (∀n3: int.((Sum n3) (\r4: int.n3<=r4)))
[Result]
X18() => X19(n3)
X19(n3) => X24(n3)
X24(n3) => X2(n3)
(X24(n3) /\ X1(x20,n3)) => n3<=x20
tt => X18()


infering new formula: Sum = (\x5: int.(\(t19: int -> *[X3(t19,x5)]).((x5>0 || (k6 0)):X4(x5) && (x5<=0 || ((Sum x5 - 1) (\y7: int.(k6 x5 + y7)))):X5(x5))))
[Result]
X2(x22) => ((x22>0 \/ X3(0,x22)) /\ (x22<=0 \/ X25(x22)))
(X2(x22) /\ X3(x23,x22)) => X1(x23,x22)
X25(x5) => X2(x5 - 1)
(X25(x5) /\ X1(x21,x5 - 1)) => X3(x5 + x21,x5)
X18() => X19(n3)
X19(n3) => X24(n3)
X24(n3) => X2(n3)
(X24(n3) /\ X1(x20,n3)) => n3<=x20
tt => X18()
[Size] 1
CHC file: /tmp/hoice-231064765.smt2
Profiling:
  CHC Solver: 0.035704 sec
did not calculate refinement. Use --show-refinement
Verification Result:
  Valid
Profiling:
  total: 0.036571 sec
```

After the change, the output becomes
```
$ rethfl input/ok/valid/sum.in 
CHC file: /tmp/hoice-74276176.smt2
Profiling:
  CHC Solver: 0.057801 sec
did not calculate refinement. Use --show-refinement
Verification Result:
  Valid
Profiling:
  total: 0.058036 sec
```
With `--show-refinement`, it is as follows
```
$ rethfl input/ok/valid/sum.in 
CHC file: /tmp/hoice-238205435.smt2
Profiling:
  CHC Solver: 0.045280 sec
Refinement types:
S: *[tt]
Sum: (x11: int -> ((t12: int -> *[t12 + -1 * x11>=0]) -> *[tt]))
Verification Result:
  Valid
Profiling:
  total: 0.045477 sec
```

All the information the has been hidden  can be shown by adding the verbose flag `-v` (with a better formatting).
```
$rethfl input/ok/valid/sum.in --show-refinement -v
[Main:Info:Input]
  S : int -> bool =ν λn3:int.Sum n3 (λr4:int.n3 <= r4)
  Sum : int -> (int -> bool) -> bool =ν
    λx5:int.λk6:(int -> bool).x5 <= 0 && k6 0 || x5 > 0 && Sum (x5 - 1) (λy7:int.k6 (x5 + y7))
[Trans:Info:Inline]
  []
[Main:Info:Simplified]
  S : int -> bool =ν λn3:int.Sum n3 (λr4:int.n3 <= r4)
  Sum : int -> (int -> bool) -> bool =ν
    λx5:int.λk6:(int -> bool).x5 <= 0 && k6 0 || x5 > 0 && Sum (x5 - 1) (λy7:int.k6 (x5 + y7))
[Main:Info:Peephole]
  S : int -> bool =ν λn3:int.Sum n3 (λr4:int.n3 <= r4)
  Sum : int -> (int -> bool) -> bool =ν
    λx5:int.λk6:(int -> bool).x5 <= 0 && k6 0 || x5 > 0 && Sum (x5 - 1) (λy7:int.k6 (x5 + y7))
[Rinfer:Info:Initial types]
  S: *[X18()]
  Sum: (x11: int -> ((t12: int -> *[X1(t12,x11)]) -> *[X2(x11)]))

[Rinfer:Info:Infering new formula]
  S = (∀n3: int.((Sum  (n3))  (\r4: int.(n3<=r4))))
[Rinfer:Info:Constraints]
  X18() => X19(n3)
  X19(n3) => X24(n3)
  X24(n3) => X2(n3)
  (X24(n3) /\ X1(x20,n3)) => n3<=x20
  tt => X18()

[Rinfer:Info:Infering new formula]
  Sum = (\x5: int.
          (\(t19: int -> *[X3(t19,x5)]).
            (((x5>0) || (k6  (0))):X4(x5)
              && ((x5<=0) || ((Sum  (x5 - 1))  (\y7: int.(k6  (x5 + y7))))):X5(x5))))
[Rinfer:Info:Constraints]
  X2(x22) => ((x22>0 \/ X3(0,x22)) /\ (x22<=0 \/ X25(x22)))
  (X2(x22) /\ X3(x23,x22)) => X1(x23,x22)
  X25(x5) => X2(x5 - 1)
  (X25(x5) /\ X1(x21,x5 - 1)) => X3(x5 + x21,x5)
  X18() => X19(n3)
  X19(n3) => X24(n3)
  X24(n3) => X2(n3)
  (X24(n3) /\ X1(x20,n3)) => n3<=x20
  tt => X18()

[Rinfer:Info:Size of constraints]
  1
CHC file: /tmp/hoice-19040976.smt2
[CHC Solver:Info:Model]
  (model
  (define-fun X2
    ( (v_0 Int) ) Bool
    true
  )
  (define-fun X25
    ( (v_0 Int) ) Bool
    (>= v_0 1)
  )
  (define-fun X24
    ( (v_0 Int) ) Bool
    true
  )
  (define-fun X19
    ( (v_0 Int) ) Bool
    true
  )
  (define-fun X18
    ( ) Bool
    true
  )
  (define-fun X3
    ( (v_0 Int) (v_1 Int) ) Bool
    (>= (+ v_0 (* (- 1) v_1)) 0)
  )
  (define-fun X1
    ( (v_0 Int) (v_1 Int) ) Bool
    (X3 v_0 v_1)
  )
)

Profiling:
  CHC Solver: 0.045952 sec
Refinement types:
S: *[tt]
Sum: (x11: int -> ((t12: int -> *[t12 + -1 * x11>=0]) -> *[tt]))
Verification Result:
  Valid
Profiling:
  total: 0.046588 sec
```
It is also possible to specify the module the user want to log.

As a byproduct, this PR implements various pretty printers. 